### PR TITLE
[Feat]: 공통 응답 객체 ApiResponse 추가

### DIFF
--- a/src/main/java/com/tave/attendance/global/common/response/ApiResponse.java
+++ b/src/main/java/com/tave/attendance/global/common/response/ApiResponse.java
@@ -1,0 +1,29 @@
+package com.tave.attendance.global.common.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ApiResponse<T>(
+        int code,
+        String message,
+        T data
+) {
+
+    public static <T> ApiResponse<T> response(HttpStatus httpStatus, String message, T data) {
+        return ApiResponse.<T>builder()
+                .code(httpStatus.value())
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> response(HttpStatus httpStatus, String message) {
+        return ApiResponse.<T>builder()
+                .code(httpStatus.value())
+                .message(message)
+                .build();
+    }
+
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #3
> Close #3

## 📑 작업 내용
> - 공통 응답 객체 ApiResponse를 추가했습니다.


### 사용 예시

<img width="1724" height="890" alt="image" src="https://github.com/user-attachments/assets/f2d9da78-209f-47e0-be0f-9c741fa1cb3c" />


```java
@RestController
public class TestController {

    @GetMapping("/v1/test")
    public ApiResponse<TestDto> test() {

        TestDto dto = new TestDto("wooseok", 10);

        return ApiResponse.response(HttpStatus.OK, "정상", dto);
    }

}
```

## ✂️ 스크린샷 (선택)
>