### PR TITLE
[Feat]: CORS 설정

### DIFF
--- a/src/main/java/com/tave/attendance/global/config/AllowedOriginsConfig.java
+++ b/src/main/java/com/tave/attendance/global/config/AllowedOriginsConfig.java
@@ -1,0 +1,14 @@
+package com.tave.attendance.global.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AllowedOriginsConfig {
+
+    public String[] getAllowedOrigins(){
+        return new String[]{
+            "*"
+        };
+    }
+
+}

--- a/src/main/java/com/tave/attendance/global/config/WebConfig.java
+++ b/src/main/java/com/tave/attendance/global/config/WebConfig.java
@@ -1,0 +1,30 @@
+package com.tave.attendance.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import static com.tave.attendance.global.auth.constants.AuthConstant.AUTH_HEADER;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AllowedOriginsConfig originConfig;
+
+    /*
+    * TODO
+    * allowedOrigins "*" 대신 직접 명시하고 Credentials true로 변경
+    * */
+
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(originConfig.getAllowedOrigins())
+                .allowedMethods("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS", "HEAD")
+                .allowedHeaders(AUTH_HEADER, "Cache-Control", "Content-Type")
+                .exposedHeaders(AUTH_HEADER)
+                .allowCredentials(false);
+    }
+
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #17
> Close #17

## 📑 작업 내용
> - CORS 설정

### WebConfig

- WebMvcConfigurer를 상속받아 MVC 웹 설정

### AllowedOriginsConfig

- 허용하고자 하는 Origins는 변경이 많아 따로 분리하여 관리
- 초기에는 `"*"`, 프론트와 연동 작업 시작하면서 Origins 명시 예정

## ✂️ 스크린샷 (선택)
>