### PR TITLE
Feat/#24/세션 crud api 구현 및 중간 테이블 구현

### DIFF
--- a/src/main/java/com/tave/attendance/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/attendance/domain/member/exception/ErrorMessage.java
@@ -14,7 +14,9 @@ public enum ErrorMessage {
     AUTHENTICATION_FAILED(UNAUTHORIZED, "[로그인]에 실패했습니다."),
 
     // Member
-    MEMBER_NOT_FOUND(BAD_REQUEST, "존재하지 않는 [회원]입니다.");
+    MEMBER_NOT_FOUND(BAD_REQUEST, "존재하지 않는 [회원]입니다."),
+
+    PHONENUMBER_MISMATCH(BAD_REQUEST, "전화번호가 일치하는 [회원]이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/tave/attendance/domain/member/exception/PhonenumberMismatchException.java
+++ b/src/main/java/com/tave/attendance/domain/member/exception/PhonenumberMismatchException.java
@@ -1,0 +1,11 @@
+package com.tave.attendance.domain.member.exception;
+
+import com.tave.attendance.global.common.exception.BaseException;
+
+import static com.tave.attendance.domain.member.exception.ErrorMessage.PHONENUMBER_MISMATCH;
+
+public class PhonenumberMismatchException extends BaseException {
+    public PhonenumberMismatchException() {
+        super(PHONENUMBER_MISMATCH.getStatus(), PHONENUMBER_MISMATCH.getMessage());
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tave/attendance/domain/member/repository/MemberRepository.java
@@ -5,6 +5,7 @@ import com.tave.attendance.domain.member.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,5 +14,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndRole(String email, Role role);
 
     Optional<Member> findByPhoneNumber(String phoneNumber);
+
+    List<Member> findAllByRole(Role role);
 
 }

--- a/src/main/java/com/tave/attendance/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tave/attendance/domain/member/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmailAndRole(String email, Role role);
 
+    Optional<Member> findByPhoneNumber(String phoneNumber);
+
 }

--- a/src/main/java/com/tave/attendance/domain/session/controller/ResponseMessage.java
+++ b/src/main/java/com/tave/attendance/domain/session/controller/ResponseMessage.java
@@ -15,7 +15,9 @@ public enum ResponseMessage {
 
     SESSION_UPDATE_SUCCESS("[세션] 수정에 성공했습니다."),
 
-    SESSION_DELETE_SUCCESS("[세션] 삭제에 성공했습니다.");
+    SESSION_DELETE_SUCCESS("[세션] 삭제에 성공했습니다."),
+
+    ATTENDANCE_MARK_SUCCESS("[출석] 출석 체크에 성공했습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tave/attendance/domain/session/controller/ResponseMessage.java
+++ b/src/main/java/com/tave/attendance/domain/session/controller/ResponseMessage.java
@@ -1,0 +1,22 @@
+package com.tave.attendance.domain.session.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    SESSION_CREATE_SUCCESS("[세션] 생성에 성공했습니다."),
+
+    SESSION_GET_ALL_SUCCESS("[세션] 전체 조회에 성공했습니다."),
+
+    SESSION_GET_SUCCESS("[세션] 단일 조회에 성공했습니다."),
+
+    SESSION_UPDATE_SUCCESS("[세션] 수정에 성공했습니다."),
+
+    SESSION_DELETE_SUCCESS("[세션] 삭제에 성공했습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/tave/attendance/domain/session/controller/SessionController.java
+++ b/src/main/java/com/tave/attendance/domain/session/controller/SessionController.java
@@ -1,0 +1,58 @@
+package com.tave.attendance.domain.session.controller;
+
+import com.tave.attendance.domain.session.dto.SessionCreateReqDto;
+import com.tave.attendance.domain.session.dto.SessionDto;
+import com.tave.attendance.domain.session.dto.SessionUpdateReqDto;
+import com.tave.attendance.domain.session.service.SessionService;
+import com.tave.attendance.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.tave.attendance.domain.session.controller.ResponseMessage.*;
+
+
+@RestController
+@RequestMapping("/v1/sessions")
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final SessionService sessionService;
+
+    @PostMapping
+    @Operation(summary = "[SESSION] 세션 생성 API")
+    public ApiResponse<SessionDto> create(@RequestBody SessionCreateReqDto request) {
+        SessionDto response = sessionService.create(request);
+        return ApiResponse.response(HttpStatus.OK, SESSION_CREATE_SUCCESS.getMessage(), response);
+    }
+
+    @GetMapping
+    @Operation(summary = "[SESSION] 전체 세션 조회 API")
+    public ApiResponse<List<SessionDto>> getAll() {
+        return ApiResponse.response(HttpStatus.OK, SESSION_GET_ALL_SUCCESS.getMessage(), sessionService.getAll());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "[SESSION] 단일 세션 조회 API")
+    public ApiResponse<SessionDto> getById(@PathVariable Long id) {
+        return ApiResponse.response(HttpStatus.OK, SESSION_GET_SUCCESS.getMessage(), sessionService.getById(id));
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "[SESSION] 세션 수정 API")
+    public ApiResponse<Void> update(@PathVariable Long id, @RequestBody SessionUpdateReqDto request) {
+        sessionService.update(id, request);
+        return ApiResponse.response(HttpStatus.OK, SESSION_UPDATE_SUCCESS.getMessage());
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "[SESSION] 세션 삭제 API")
+    public ApiResponse<Void> delete(@PathVariable Long id) {
+        sessionService.delete(id);
+        return ApiResponse.response(HttpStatus.OK, SESSION_DELETE_SUCCESS.getMessage());
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/session/controller/SessionController.java
+++ b/src/main/java/com/tave/attendance/domain/session/controller/SessionController.java
@@ -3,12 +3,13 @@ package com.tave.attendance.domain.session.controller;
 import com.tave.attendance.domain.session.dto.SessionCreateReqDto;
 import com.tave.attendance.domain.session.dto.SessionDto;
 import com.tave.attendance.domain.session.dto.SessionUpdateReqDto;
+import com.tave.attendance.domain.session.service.AttendanceService;
 import com.tave.attendance.domain.session.service.SessionService;
+import com.tave.attendance.domain.sessionmember.dto.MarkAttendanceReqDto;
 import com.tave.attendance.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,11 +23,12 @@ import static com.tave.attendance.domain.session.controller.ResponseMessage.*;
 public class SessionController {
 
     private final SessionService sessionService;
+    private final AttendanceService attendanceService;
 
     @PostMapping
     @Operation(summary = "[SESSION] 세션 생성 API")
-    public ApiResponse<SessionDto> create(@RequestBody SessionCreateReqDto request) {
-        SessionDto response = sessionService.create(request);
+    public ApiResponse<SessionDto> create(@RequestBody SessionCreateReqDto req) {
+        SessionDto response = sessionService.create(req);
         return ApiResponse.response(HttpStatus.OK, SESSION_CREATE_SUCCESS.getMessage(), response);
     }
 
@@ -44,8 +46,8 @@ public class SessionController {
 
     @PutMapping("/{id}")
     @Operation(summary = "[SESSION] 세션 수정 API")
-    public ApiResponse<Void> update(@PathVariable Long id, @RequestBody SessionUpdateReqDto request) {
-        sessionService.update(id, request);
+    public ApiResponse<Void> update(@PathVariable Long id, @RequestBody SessionUpdateReqDto req) {
+        sessionService.update(id, req);
         return ApiResponse.response(HttpStatus.OK, SESSION_UPDATE_SUCCESS.getMessage());
     }
 
@@ -54,5 +56,12 @@ public class SessionController {
     public ApiResponse<Void> delete(@PathVariable Long id) {
         sessionService.delete(id);
         return ApiResponse.response(HttpStatus.OK, SESSION_DELETE_SUCCESS.getMessage());
+    }
+
+    @PostMapping("/{id}/mark")
+    @Operation(summary = "[SESSION] 출석 처리 (전화번호 인증)")
+    public ApiResponse<Void> markAttendance(@PathVariable Long id, @RequestBody MarkAttendanceReqDto req) {
+        attendanceService.markAttendance(id, req);
+        return ApiResponse.response(HttpStatus.OK, ATTENDANCE_MARK_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/tave/attendance/domain/session/dto/SessionCreateReqDto.java
+++ b/src/main/java/com/tave/attendance/domain/session/dto/SessionCreateReqDto.java
@@ -1,0 +1,12 @@
+package com.tave.attendance.domain.session.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record SessionCreateReqDto(
+        String title,
+        LocalDate sessionDate,
+        LocalTime tardyTime,
+        LocalTime earlyBirdDeadline,
+        LocalTime seminarTime
+) {}

--- a/src/main/java/com/tave/attendance/domain/session/dto/SessionDto.java
+++ b/src/main/java/com/tave/attendance/domain/session/dto/SessionDto.java
@@ -1,0 +1,13 @@
+package com.tave.attendance.domain.session.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record SessionDto(
+        Long id,
+        String title,
+        LocalDate sessionDate,
+        LocalTime tardyTime,
+        LocalTime earlyBirdDeadline,
+        LocalTime seminarTime
+) {}

--- a/src/main/java/com/tave/attendance/domain/session/dto/SessionUpdateReqDto.java
+++ b/src/main/java/com/tave/attendance/domain/session/dto/SessionUpdateReqDto.java
@@ -1,0 +1,12 @@
+package com.tave.attendance.domain.session.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record SessionUpdateReqDto(
+        String title,
+        LocalDate sessionDate,
+        LocalTime tardyTime,
+        LocalTime earlyBirdDeadline,
+        LocalTime seminarTime
+) {}

--- a/src/main/java/com/tave/attendance/domain/session/entity/Session.java
+++ b/src/main/java/com/tave/attendance/domain/session/entity/Session.java
@@ -1,0 +1,61 @@
+package com.tave.attendance.domain.session.entity;
+
+import com.tave.attendance.domain.sessionmember.entity.SessionMember;
+import com.tave.attendance.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Table(name = "session")
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Session extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 행사명
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    // 시작 날짜 (Date)
+    @Column(name = "session_date", nullable = false)
+    private LocalDate sessionDate;
+
+    // 지각 시간 (Time)
+    @Column(name = "tardy_time", nullable = false)
+    private LocalTime tardyTime;
+
+    // 얼리버드 종료 시간 (Time)
+    @Column(name = "early_bird_deadline", nullable = false)
+    private LocalTime earlyBirdDeadline;
+
+    // 기술세미나 시간 (nullable Time)
+    @Column(name = "seminar_time")
+    private LocalTime seminarTime;
+
+    @OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SessionMember> sessionMembers = new ArrayList<>();
+
+    public void update(String title,
+                       LocalDate sessionDate,
+                       LocalTime tardyTime,
+                       LocalTime earlyBirdDeadline,
+                       LocalTime seminarTime) {
+        if (title != null) this.title = title;
+        if (sessionDate != null) this.sessionDate = sessionDate;
+        if (tardyTime != null) this.tardyTime = tardyTime;
+        if (earlyBirdDeadline != null) this.earlyBirdDeadline = earlyBirdDeadline;
+        if (seminarTime != null) this.seminarTime = seminarTime;
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/session/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/attendance/domain/session/exception/ErrorMessage.java
@@ -1,0 +1,18 @@
+package com.tave.attendance.domain.session.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    SESSION_NOT_FOUND(BAD_REQUEST, "존재하지 않는 [세션]입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+}

--- a/src/main/java/com/tave/attendance/domain/session/exception/SessionNotFoundException.java
+++ b/src/main/java/com/tave/attendance/domain/session/exception/SessionNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tave.attendance.domain.session.exception;
+
+import com.tave.attendance.global.common.exception.BaseException;
+
+import static com.tave.attendance.domain.session.exception.ErrorMessage.SESSION_NOT_FOUND;
+
+public class SessionNotFoundException extends BaseException {
+    public SessionNotFoundException() {
+        super(SESSION_NOT_FOUND.getStatus(), SESSION_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/session/repository/SessionRepository.java
+++ b/src/main/java/com/tave/attendance/domain/session/repository/SessionRepository.java
@@ -1,0 +1,7 @@
+package com.tave.attendance.domain.session.repository;
+
+import com.tave.attendance.domain.session.entity.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SessionRepository extends JpaRepository<Session, Long> {
+}

--- a/src/main/java/com/tave/attendance/domain/session/service/AttendanceService.java
+++ b/src/main/java/com/tave/attendance/domain/session/service/AttendanceService.java
@@ -1,0 +1,55 @@
+package com.tave.attendance.domain.session.service;
+
+import com.tave.attendance.domain.member.entity.Member;
+import com.tave.attendance.domain.member.exception.PhonenumberMismatchException;
+import com.tave.attendance.domain.member.repository.MemberRepository;
+import com.tave.attendance.domain.session.entity.Session;
+import com.tave.attendance.domain.session.exception.SessionNotFoundException;
+import com.tave.attendance.domain.session.repository.SessionRepository;
+import com.tave.attendance.domain.sessionmember.dto.MarkAttendanceReqDto;
+import com.tave.attendance.domain.sessionmember.entity.SessionMember;
+import com.tave.attendance.domain.sessionmember.entity.Status;
+import com.tave.attendance.domain.sessionmember.exception.SessionMemberNotFoundException;
+import com.tave.attendance.domain.sessionmember.repository.SessionMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceService {
+
+    private final SessionRepository sessionRepository;
+    private final MemberRepository memberRepository;
+    private final SessionMemberRepository sessionMemberRepository;
+
+    @Transactional
+    public void markAttendance(Long sessionId, MarkAttendanceReqDto req) {
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(SessionNotFoundException::new);
+
+        Member member = memberRepository.findByPhoneNumber(req.phoneNumber())
+                .orElseThrow(PhonenumberMismatchException::new);
+
+        SessionMember sm = sessionMemberRepository.findBySession_IdAndMember_Id(session.getId(), member.getId())
+                .orElseThrow(SessionMemberNotFoundException::new);
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime earlyBirdEnd = LocalDateTime.of(session.getSessionDate(), session.getEarlyBirdDeadline());
+        LocalDateTime tardyStart   = LocalDateTime.of(session.getSessionDate(), session.getTardyTime());
+
+        Status status;
+        if (now.isBefore(earlyBirdEnd)) {
+            status = Status.EARLY_BIRD;
+        } else if (!now.isAfter(tardyStart)) {
+            status = Status.ATTENDANCE;
+        } else {
+            status = Status.TARDY;
+        }
+
+        sm.mark(status, now);
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/session/service/SessionService.java
+++ b/src/main/java/com/tave/attendance/domain/session/service/SessionService.java
@@ -1,0 +1,72 @@
+package com.tave.attendance.domain.session.service;
+
+import com.tave.attendance.domain.session.dto.SessionCreateReqDto;
+import com.tave.attendance.domain.session.dto.SessionDto;
+import com.tave.attendance.domain.session.dto.SessionUpdateReqDto;
+import com.tave.attendance.domain.session.entity.Session;
+import com.tave.attendance.domain.session.exception.SessionNotFoundException;
+import com.tave.attendance.domain.session.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final SessionRepository sessionRepository;
+
+    public SessionDto create(SessionCreateReqDto req) {
+        Session session = Session.builder()
+                .title(req.title())
+                .sessionDate(req.sessionDate())
+                .tardyTime(req.tardyTime())
+                .earlyBirdDeadline(req.earlyBirdDeadline())
+                .seminarTime(req.seminarTime())
+                .build();
+        return toDto(sessionRepository.save(session));
+    }
+
+    public List<SessionDto> getAll() {
+        return sessionRepository.findAll().stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    public SessionDto getById(Long id) {
+        return sessionRepository.findById(id)
+                .map(this::toDto)
+                .orElseThrow(SessionNotFoundException::new);
+    }
+
+    @Transactional
+    public void update(Long id, SessionUpdateReqDto req) {
+        Session session = sessionRepository.findById(id)
+                .orElseThrow(SessionNotFoundException::new);
+
+        session.update(
+                req.title(),
+                req.sessionDate(),
+                req.tardyTime(),
+                req.earlyBirdDeadline(),
+                req.seminarTime()
+        );
+    }
+
+    public void delete(Long id) {
+        sessionRepository.deleteById(id);
+    }
+
+    private SessionDto toDto(Session session) {
+        return new SessionDto(
+                session.getId(),
+                session.getTitle(),
+                session.getSessionDate(),
+                session.getTardyTime(),
+                session.getEarlyBirdDeadline(),
+                session.getSeminarTime()
+        );
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/session/service/SessionService.java
+++ b/src/main/java/com/tave/attendance/domain/session/service/SessionService.java
@@ -1,6 +1,7 @@
 package com.tave.attendance.domain.session.service;
 
 import com.tave.attendance.domain.member.entity.Member;
+import com.tave.attendance.domain.member.entity.Role;
 import com.tave.attendance.domain.member.repository.MemberRepository;
 import com.tave.attendance.domain.session.dto.SessionCreateReqDto;
 import com.tave.attendance.domain.session.dto.SessionDto;
@@ -36,7 +37,7 @@ public class SessionService {
                 .build();
         Session saved = sessionRepository.save(session);
 
-        List<Member> members = memberRepository.findAll();
+        List<Member> members = memberRepository.findAllByRole(Role.MEMBER);
         List<SessionMember> links = members.stream()
                 .map(m -> SessionMember.builder()
                         .session(saved)

--- a/src/main/java/com/tave/attendance/domain/sessionmember/dto/MarkAttendanceReqDto.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/dto/MarkAttendanceReqDto.java
@@ -1,0 +1,4 @@
+package com.tave.attendance.domain.sessionmember.dto;
+
+public record MarkAttendanceReqDto(String phoneNumber) {
+}

--- a/src/main/java/com/tave/attendance/domain/sessionmember/entity/SessionMember.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/entity/SessionMember.java
@@ -1,0 +1,47 @@
+package com.tave.attendance.domain.sessionmember.entity;
+
+import com.tave.attendance.domain.member.entity.Member;
+import com.tave.attendance.domain.session.entity.Session;
+import com.tave.attendance.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Table(
+        name = "session_member",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_session_member", columnNames = {"session_id", "member_id"})
+        }
+)
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionMember extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 세션 ID FK
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", nullable = false)
+    private Session session;
+
+    // 멤버 ID FK
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 출석 상태 (varchar)
+    @Column(name = "status", nullable = false)
+    private String status;
+
+    // 출석 시간 (DateTime)
+    @Column(name = "attendance_time")
+    private LocalDateTime attendanceTime;
+}

--- a/src/main/java/com/tave/attendance/domain/sessionmember/entity/SessionMember.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/entity/SessionMember.java
@@ -27,21 +27,28 @@ public class SessionMember extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 세션 ID FK
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "session_id", nullable = false)
     private Session session;
 
-    // 멤버 ID FK
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    // 출석 상태 (varchar)
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    private String status;
+    private Status status;
 
-    // 출석 시간 (DateTime)
     @Column(name = "attendance_time")
     private LocalDateTime attendanceTime;
+
+    @PrePersist
+    void onCreate() {
+        if (status == null) status = Status.ABSENT; // 기본값
+    }
+
+    public void mark(Status status, LocalDateTime at) {
+        this.status = status;
+        this.attendanceTime = at;
+    }
 }

--- a/src/main/java/com/tave/attendance/domain/sessionmember/entity/Status.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/entity/Status.java
@@ -1,0 +1,8 @@
+package com.tave.attendance.domain.sessionmember.entity;
+
+public enum Status {
+    ABSENT,        // 기본값(결석)
+    EARLY_BIRD,    // 얼리버드
+    ATTENDANCE,       // 정상 출석
+    TARDY          // 지각
+}

--- a/src/main/java/com/tave/attendance/domain/sessionmember/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/exception/ErrorMessage.java
@@ -1,0 +1,17 @@
+package com.tave.attendance.domain.sessionmember.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    SESSION_MEMBER_NOT_FOUND(NOT_FOUND, "[세션] [멤버]를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/tave/attendance/domain/sessionmember/exception/SessionMemberNotFoundException.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/exception/SessionMemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tave.attendance.domain.sessionmember.exception;
+
+import com.tave.attendance.global.common.exception.BaseException;
+
+import static com.tave.attendance.domain.member.exception.ErrorMessage.PHONENUMBER_MISMATCH;
+
+public class SessionMemberNotFoundException extends BaseException {
+    public SessionMemberNotFoundException() {
+        super(PHONENUMBER_MISMATCH.getStatus(), PHONENUMBER_MISMATCH.getMessage());
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/sessionmember/repository/SessionMemberRepository.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/repository/SessionMemberRepository.java
@@ -1,0 +1,10 @@
+package com.tave.attendance.domain.sessionmember.repository;
+
+import com.tave.attendance.domain.sessionmember.entity.SessionMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SessionMemberRepository extends JpaRepository<SessionMember, Long> {
+    Optional<SessionMember> findBySession_IdAndMember_Id(Long sessionId, Long memberId);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
 
 tave:
   key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #24
> Close #24

## 📑 작업 내용
>
- Session CRUD api 작성
- Session 생성 시 Role이 MEMBER인 member를 가져와 SessionMember 생성
- markAttendance 호출로 출석 처리
  1. 출석 시간이 얼리버드 시간 이전이면 얼리버드
  2. 얼리버드 시간 이후 지각 시간 이전이면 일반출석
  3. 지각 시간 이후이면 지각


## ✂️ 스크린샷 (선택)
>