### PR TITLE
[Feat] 세션별 파트별 출석 상태 출력 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.assertj:assertj-core:3.25.3'
+	testImplementation 'org.mockito:mockito-inline:5.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tave/attendance/domain/member/entity/Member.java
+++ b/src/main/java/com/tave/attendance/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.tave.attendance.domain.member.entity;
 
+import com.tave.attendance.domain.member.utils.PhoneNumberUtils;
 import com.tave.attendance.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -25,6 +26,10 @@ public class Member extends BaseTimeEntity {
     @Column(name = "phone_number", unique = true)
     String phoneNumber;
 
+    @Column(name="phone_number_digits", length = 20)
+    private String phoneNumberDigits;
+
+
     @Column(name = "email", unique = true)
     String email;
 
@@ -47,5 +52,10 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "field")
     FieldType field;
+
+    @PrePersist @PreUpdate
+    void normalizePhone() {
+        this.phoneNumberDigits = PhoneNumberUtils.toDigits(this.phoneNumber);
+    }
 
 }

--- a/src/main/java/com/tave/attendance/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/attendance/domain/member/exception/ErrorMessage.java
@@ -16,7 +16,9 @@ public enum ErrorMessage {
     // Member
     MEMBER_NOT_FOUND(BAD_REQUEST, "존재하지 않는 [회원]입니다."),
 
-    PHONENUMBER_MISMATCH(BAD_REQUEST, "전화번호가 일치하는 [회원]이 없습니다.");
+    PHONENUMBER_MISMATCH(BAD_REQUEST, "전화번호가 일치하는 [회원]이 없습니다."),
+
+    INVALID_PHONE_LAST8(BAD_REQUEST, "전화번호 끝 8자리를 정확히 입력하세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/tave/attendance/domain/member/exception/InvalidPhoneLast8Exception.java
+++ b/src/main/java/com/tave/attendance/domain/member/exception/InvalidPhoneLast8Exception.java
@@ -1,0 +1,11 @@
+package com.tave.attendance.domain.member.exception;
+
+import com.tave.attendance.global.common.exception.BaseException;
+
+import static com.tave.attendance.domain.member.exception.ErrorMessage.INVALID_PHONE_LAST8;
+
+public class InvalidPhoneLast8Exception extends BaseException {
+    public InvalidPhoneLast8Exception() {
+        super(INVALID_PHONE_LAST8.getStatus(), INVALID_PHONE_LAST8.getMessage());
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tave/attendance/domain/member/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package com.tave.attendance.domain.member.repository;
 import com.tave.attendance.domain.member.entity.Member;
 import com.tave.attendance.domain.member.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,5 +18,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByPhoneNumber(String phoneNumber);
 
     List<Member> findAllByRole(Role role);
+
+    @Query(value = "SELECT * FROM member m WHERE RIGHT(m.phone_number_digits, 8) = :last8 LIMIT 1", nativeQuery = true)
+    Optional<Member> findByPhoneTail(@Param("last8") String last8);
 
 }

--- a/src/main/java/com/tave/attendance/domain/member/utils/PhoneNumberUtils.java
+++ b/src/main/java/com/tave/attendance/domain/member/utils/PhoneNumberUtils.java
@@ -1,0 +1,15 @@
+package com.tave.attendance.domain.member.utils;
+
+public final class PhoneNumberUtils {
+    private PhoneNumberUtils() {}
+
+    public static String toDigits(String raw) {
+        if (raw == null) return "";
+        return raw.replaceAll("[^0-9]", "");
+    }
+
+    public static String last8(String raw) {
+        String digits = toDigits(raw);
+        return digits.length() >= 8 ? digits.substring(digits.length() - 8) : digits;
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/session/controller/SessionController.java
+++ b/src/main/java/com/tave/attendance/domain/session/controller/SessionController.java
@@ -6,6 +6,8 @@ import com.tave.attendance.domain.session.dto.SessionUpdateReqDto;
 import com.tave.attendance.domain.session.service.AttendanceService;
 import com.tave.attendance.domain.session.service.SessionService;
 import com.tave.attendance.domain.sessionmember.dto.MarkAttendanceReqDto;
+import com.tave.attendance.global.auth.annotations.AuthGuard;
+import com.tave.attendance.global.auth.guards.AdminGuard;
 import com.tave.attendance.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class SessionController {
 
     @PostMapping
     @Operation(summary = "[SESSION] 세션 생성 API")
+    @AuthGuard({AdminGuard.class})
     public ApiResponse<SessionDto> create(@RequestBody SessionCreateReqDto req) {
         SessionDto response = sessionService.create(req);
         return ApiResponse.response(HttpStatus.OK, SESSION_CREATE_SUCCESS.getMessage(), response);
@@ -34,18 +37,21 @@ public class SessionController {
 
     @GetMapping
     @Operation(summary = "[SESSION] 전체 세션 조회 API")
+    @AuthGuard({AdminGuard.class})
     public ApiResponse<List<SessionDto>> getAll() {
         return ApiResponse.response(HttpStatus.OK, SESSION_GET_ALL_SUCCESS.getMessage(), sessionService.getAll());
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "[SESSION] 단일 세션 조회 API")
+    @AuthGuard({AdminGuard.class})
     public ApiResponse<SessionDto> getById(@PathVariable Long id) {
         return ApiResponse.response(HttpStatus.OK, SESSION_GET_SUCCESS.getMessage(), sessionService.getById(id));
     }
 
     @PutMapping("/{id}")
     @Operation(summary = "[SESSION] 세션 수정 API")
+    @AuthGuard({AdminGuard.class})
     public ApiResponse<Void> update(@PathVariable Long id, @RequestBody SessionUpdateReqDto req) {
         sessionService.update(id, req);
         return ApiResponse.response(HttpStatus.OK, SESSION_UPDATE_SUCCESS.getMessage());
@@ -53,6 +59,7 @@ public class SessionController {
 
     @DeleteMapping("/{id}")
     @Operation(summary = "[SESSION] 세션 삭제 API")
+    @AuthGuard({AdminGuard.class})
     public ApiResponse<Void> delete(@PathVariable Long id) {
         sessionService.delete(id);
         return ApiResponse.response(HttpStatus.OK, SESSION_DELETE_SUCCESS.getMessage());

--- a/src/main/java/com/tave/attendance/domain/session/service/AttendanceService.java
+++ b/src/main/java/com/tave/attendance/domain/session/service/AttendanceService.java
@@ -34,7 +34,7 @@ public class AttendanceService {
         Member member = memberRepository.findByPhoneNumber(req.phoneNumber())
                 .orElseThrow(PhonenumberMismatchException::new);
 
-        SessionMember sm = sessionMemberRepository.findBySession_IdAndMember_Id(session.getId(), member.getId())
+        SessionMember sm = sessionMemberRepository.findBySessionIdAndMemberId(session.getId(), member.getId())
                 .orElseThrow(SessionMemberNotFoundException::new);
 
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/tave/attendance/domain/session/service/AttendanceService.java
+++ b/src/main/java/com/tave/attendance/domain/session/service/AttendanceService.java
@@ -1,8 +1,10 @@
 package com.tave.attendance.domain.session.service;
 
 import com.tave.attendance.domain.member.entity.Member;
+import com.tave.attendance.domain.member.exception.InvalidPhoneLast8Exception;
 import com.tave.attendance.domain.member.exception.PhonenumberMismatchException;
 import com.tave.attendance.domain.member.repository.MemberRepository;
+import com.tave.attendance.domain.member.utils.PhoneNumberUtils;
 import com.tave.attendance.domain.session.entity.Session;
 import com.tave.attendance.domain.session.exception.SessionNotFoundException;
 import com.tave.attendance.domain.session.repository.SessionRepository;
@@ -31,7 +33,12 @@ public class AttendanceService {
         Session session = sessionRepository.findById(sessionId)
                 .orElseThrow(SessionNotFoundException::new);
 
-        Member member = memberRepository.findByPhoneNumber(req.phoneNumber())
+        String last8 = PhoneNumberUtils.last8(req.phoneNumber());
+        if (last8.length() != 8) {
+            throw new InvalidPhoneLast8Exception();
+        }
+
+        Member member = memberRepository.findByPhoneTail(last8)
                 .orElseThrow(PhonenumberMismatchException::new);
 
         SessionMember sm = sessionMemberRepository.findBySessionIdAndMemberId(session.getId(), member.getId())

--- a/src/main/java/com/tave/attendance/domain/sessionmember/controller/ResponseMessage.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/controller/ResponseMessage.java
@@ -1,0 +1,13 @@
+package com.tave.attendance.domain.sessionmember.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+    SESSION_MEMBER_GET_SUCCESS("[세션 멤버] 세션 멤버 조회에 성공했습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/tave/attendance/domain/sessionmember/controller/SessionMemberController.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/controller/SessionMemberController.java
@@ -1,0 +1,37 @@
+package com.tave.attendance.domain.sessionmember.controller;
+
+import com.tave.attendance.domain.member.entity.FieldType;
+import com.tave.attendance.domain.session.service.AttendanceService;
+import com.tave.attendance.domain.sessionmember.dto.SessionMemberResDto;
+import com.tave.attendance.domain.sessionmember.entity.Status;
+import com.tave.attendance.domain.sessionmember.service.SessionMemberService;
+import com.tave.attendance.global.auth.annotations.AuthGuard;
+import com.tave.attendance.global.auth.guards.AdminGuard;
+import com.tave.attendance.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.tave.attendance.domain.sessionmember.controller.ResponseMessage.SESSION_MEMBER_GET_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+public class SessionMemberController {
+
+    private final SessionMemberService sessionMemberService;
+
+    @GetMapping("/v1/sessions/{sessionId}/members")
+    @Operation(summary = "[SESSION MEMBER] 세션 멤버 조회 API")
+    @AuthGuard({AdminGuard.class})
+    public ApiResponse<List<SessionMemberResDto>> getMembers(
+            @PathVariable Long sessionId,
+            @RequestParam(required = false) Status status,
+            @RequestParam(required = false, name = "field") FieldType field
+    ) {
+        return ApiResponse.response(
+                HttpStatus.OK, SESSION_MEMBER_GET_SUCCESS.getMessage(), sessionMemberService.getMembers(sessionId, status, field));
+    }
+}

--- a/src/main/java/com/tave/attendance/domain/sessionmember/dto/MarkAttendanceReqDto.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/dto/MarkAttendanceReqDto.java
@@ -1,4 +1,7 @@
 package com.tave.attendance.domain.sessionmember.dto;
 
-public record MarkAttendanceReqDto(String phoneNumber) {
-}
+public record MarkAttendanceReqDto(
+        @jakarta.validation.constraints.NotBlank
+        @jakarta.validation.constraints.Pattern(regexp="^\\d{8}$", message="전화번호 끝 8자리만 입력하세요.")
+        String phoneNumber
+) {}

--- a/src/main/java/com/tave/attendance/domain/sessionmember/dto/SessionMemberResDto.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/dto/SessionMemberResDto.java
@@ -1,0 +1,11 @@
+package com.tave.attendance.domain.sessionmember.dto;
+
+import com.tave.attendance.domain.member.entity.FieldType;
+import com.tave.attendance.domain.sessionmember.entity.Status;
+
+public record SessionMemberResDto(
+        Long memberId,
+        String username,
+        FieldType field,
+        Status status
+) {}

--- a/src/main/java/com/tave/attendance/domain/sessionmember/entity/Status.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/entity/Status.java
@@ -3,6 +3,6 @@ package com.tave.attendance.domain.sessionmember.entity;
 public enum Status {
     ABSENT,        // 기본값(결석)
     EARLY_BIRD,    // 얼리버드
-    ATTENDANCE,       // 정상 출석
+    ATTENDANCE,    // 정상 출석
     TARDY          // 지각
 }

--- a/src/main/java/com/tave/attendance/domain/sessionmember/repository/SessionMemberRepository.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/repository/SessionMemberRepository.java
@@ -1,10 +1,35 @@
 package com.tave.attendance.domain.sessionmember.repository;
 
+import com.tave.attendance.domain.member.entity.FieldType;
+import com.tave.attendance.domain.sessionmember.dto.SessionMemberResDto;
 import com.tave.attendance.domain.sessionmember.entity.SessionMember;
+import com.tave.attendance.domain.sessionmember.entity.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SessionMemberRepository extends JpaRepository<SessionMember, Long> {
     Optional<SessionMember> findBySessionIdAndMemberId(Long sessionId, Long memberId);
+
+    @Query("""
+        select new com.tave.attendance.domain.sessionmember.dto.SessionMemberResDto(
+            m.id, m.username, m.field, sm.status
+        )
+        from SessionMember sm
+        join sm.member m
+        where sm.session.id = :sessionId
+          and (:status is null or sm.status = :status)
+          and (:field  is null or m.field   = :field)
+        order by m.username asc
+    """)
+    List<SessionMemberResDto> findMembersOfSession(
+            @Param("sessionId") Long sessionId,
+            @Param("status") Status status,
+            @Param("field")  FieldType field
+    );
 }

--- a/src/main/java/com/tave/attendance/domain/sessionmember/repository/SessionMemberRepository.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/repository/SessionMemberRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface SessionMemberRepository extends JpaRepository<SessionMember, Long> {
-    Optional<SessionMember> findBySession_IdAndMember_Id(Long sessionId, Long memberId);
+    Optional<SessionMember> findBySessionIdAndMemberId(Long sessionId, Long memberId);
 }

--- a/src/main/java/com/tave/attendance/domain/sessionmember/service/SessionMemberService.java
+++ b/src/main/java/com/tave/attendance/domain/sessionmember/service/SessionMemberService.java
@@ -1,0 +1,24 @@
+package com.tave.attendance.domain.sessionmember.service;
+
+import com.tave.attendance.domain.member.entity.FieldType;
+import com.tave.attendance.domain.sessionmember.dto.SessionMemberResDto;
+import com.tave.attendance.domain.sessionmember.entity.Status;
+import com.tave.attendance.domain.sessionmember.repository.SessionMemberRepository;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SessionMemberService {
+
+    private final SessionMemberRepository sessionMemberRepository;
+
+    public List<SessionMemberResDto> getMembers(
+            Long sessionId, @Nullable Status status, @Nullable FieldType field
+    ) {
+        return sessionMemberRepository.findMembersOfSession(sessionId, status, field);
+    }
+}

--- a/src/test/java/com/tave/attendance/domain/session/service/AttendanceServiceTest.java
+++ b/src/test/java/com/tave/attendance/domain/session/service/AttendanceServiceTest.java
@@ -1,0 +1,191 @@
+package com.tave.attendance.domain.session.service;
+
+import com.tave.attendance.domain.member.entity.Member;
+import com.tave.attendance.domain.member.exception.PhonenumberMismatchException;
+import com.tave.attendance.domain.member.repository.MemberRepository;
+import com.tave.attendance.domain.session.entity.Session;
+import com.tave.attendance.domain.session.exception.SessionNotFoundException;
+import com.tave.attendance.domain.session.repository.SessionRepository;
+import com.tave.attendance.domain.sessionmember.dto.MarkAttendanceReqDto;
+import com.tave.attendance.domain.sessionmember.entity.SessionMember;
+import com.tave.attendance.domain.sessionmember.entity.Status;
+import com.tave.attendance.domain.sessionmember.exception.SessionMemberNotFoundException;
+import com.tave.attendance.domain.sessionmember.repository.SessionMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AttendanceServiceTest {
+
+    @Mock
+    SessionRepository sessionRepository;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
+    SessionMemberRepository sessionMemberRepository;
+
+    // 실제 서비스 클래스명에 맞게 수정하세요.
+    AttendanceService attendanceService;
+
+    @BeforeEach
+    void setUp() {
+        attendanceService = new AttendanceService(sessionRepository, memberRepository, sessionMemberRepository);
+    }
+
+    @Test
+    void markAttendance_earlyBird면_EARLY_BIRD로_마킹() {
+        // given
+        Long sessionId = 1L;
+        String phone = "010-1234-5678";
+
+        Session session = mock(Session.class);
+        Member member = mock(Member.class);
+        SessionMember sm = mock(SessionMember.class);
+
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(memberRepository.findByPhoneNumber(phone)).thenReturn(Optional.of(member));
+        when(sessionMemberRepository.findBySessionIdAndMemberId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(sm));
+
+        // 세션 시간 정보 (조정 가능)
+        LocalDate sessionDate = LocalDate.of(2025, 9, 4);
+        LocalTime earlyBirdDeadline = LocalTime.of(9, 30);
+        LocalTime tardyTime = LocalTime.of(10, 10);
+
+        when(session.getId()).thenReturn(sessionId);
+        when(session.getSessionDate()).thenReturn(sessionDate);
+        when(session.getEarlyBirdDeadline()).thenReturn(earlyBirdDeadline);
+        when(session.getTardyTime()).thenReturn(tardyTime);
+
+        // now 가 earlyBirdEnd 이전
+        LocalDateTime now = LocalDateTime.of(2025, 9, 4, 9, 0);
+
+        try (MockedStatic<LocalDateTime> mocked = mockStatic(LocalDateTime.class, CALLS_REAL_METHODS)) {
+            mocked.when(LocalDateTime::now).thenReturn(now);
+
+            // when
+            attendanceService.markAttendance(sessionId, new MarkAttendanceReqDto(phone));
+
+            // then
+            verify(sm).mark(eq(Status.EARLY_BIRD), eq(now));
+        }
+    }
+
+    @Test
+    void markAttendance_정시면_ATTENDANCE로_마킹() {
+        Long sessionId = 1L;
+        String phone = "010-0000-0000";
+
+        Session session = mock(Session.class);
+        Member member = mock(Member.class);
+        SessionMember sm = mock(SessionMember.class);
+
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(memberRepository.findByPhoneNumber(phone)).thenReturn(Optional.of(member));
+        when(sessionMemberRepository.findBySessionIdAndMemberId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(sm));
+
+        LocalDate sessionDate = LocalDate.of(2025, 9, 4);
+        LocalTime earlyBirdDeadline = LocalTime.of(9, 30);
+        LocalTime tardyTime = LocalTime.of(10, 10);
+
+        when(session.getId()).thenReturn(sessionId);
+        when(session.getSessionDate()).thenReturn(sessionDate);
+        when(session.getEarlyBirdDeadline()).thenReturn(earlyBirdDeadline);
+        when(session.getTardyTime()).thenReturn(tardyTime);
+
+        // now 가 earlyBirdEnd 이후이면서 tardyStart 보다 같거나 이른 시각
+        LocalDateTime now = LocalDateTime.of(2025, 9, 4, 9, 45);
+
+        try (MockedStatic<LocalDateTime> mocked = mockStatic(LocalDateTime.class, CALLS_REAL_METHODS)) {
+            mocked.when(LocalDateTime::now).thenReturn(now);
+
+            attendanceService.markAttendance(sessionId, new MarkAttendanceReqDto(phone));
+
+            verify(sm).mark(eq(Status.ATTENDANCE), eq(now));
+        }
+    }
+
+    @Test
+    void markAttendance_지각이면_TARDY로_마킹() {
+        Long sessionId = 1L;
+        String phone = "010-1111-2222";
+
+        Session session = mock(Session.class);
+        Member member = mock(Member.class);
+        SessionMember sm = mock(SessionMember.class);
+
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(memberRepository.findByPhoneNumber(phone)).thenReturn(Optional.of(member));
+        when(sessionMemberRepository.findBySessionIdAndMemberId(anyLong(), anyLong()))
+                .thenReturn(Optional.of(sm));
+
+        LocalDate sessionDate = LocalDate.of(2025, 9, 4);
+        LocalTime earlyBirdDeadline = LocalTime.of(9, 30);
+        LocalTime tardyTime = LocalTime.of(10, 10);
+
+        when(session.getId()).thenReturn(sessionId);
+        when(session.getSessionDate()).thenReturn(sessionDate);
+        when(session.getEarlyBirdDeadline()).thenReturn(earlyBirdDeadline);
+        when(session.getTardyTime()).thenReturn(tardyTime);
+
+        // now 가 tardyStart 이후
+        LocalDateTime now = LocalDateTime.of(2025, 9, 4, 10, 11);
+
+        try (MockedStatic<LocalDateTime> mocked = mockStatic(LocalDateTime.class, CALLS_REAL_METHODS)) {
+            mocked.when(LocalDateTime::now).thenReturn(now);
+
+            attendanceService.markAttendance(sessionId, new MarkAttendanceReqDto(phone));
+
+            verify(sm).mark(eq(Status.TARDY), eq(now));
+        }
+    }
+
+    @Test
+    void session_없으면_SessionNotFoundException() {
+        Long sessionId = 99L;
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                attendanceService.markAttendance(sessionId, new MarkAttendanceReqDto("010-0000-0000"))
+        ).isInstanceOf(SessionNotFoundException.class);
+    }
+
+    @Test
+    void member_없으면_PhonenumberMismatchException() {
+        Long sessionId = 1L;
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(mock(Session.class)));
+        when(memberRepository.findByPhoneNumber(anyString())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                attendanceService.markAttendance(sessionId, new MarkAttendanceReqDto("010-xxxx-xxxx"))
+        ).isInstanceOf(PhonenumberMismatchException.class);
+    }
+
+    @Test
+    void sessionMember_없으면_SessionMemberNotFoundException() {
+        Long sessionId = 1L;
+        Session session = mock(Session.class);
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(memberRepository.findByPhoneNumber(anyString())).thenReturn(Optional.of(mock(Member.class)));
+        when(sessionMemberRepository.findBySessionIdAndMemberId(anyLong(), anyLong()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                attendanceService.markAttendance(sessionId, new MarkAttendanceReqDto("010-1234-5678"))
+        ).isInstanceOf(SessionMemberNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #26 
> Close #26

## 📑 작업 내용
>
 - 운영자용 api에 AuthGuard 추가
 - AttendanceService CamelCase로 수정
 - 세션별 + 파트별 회원 출석 상태 출력 api 구현
 - 전화번호를 뒷자리 8자리만 저장하도록 column 추가 후 별도 저장

## ✂️ 스크린샷 (선택)
>